### PR TITLE
Add missing cache control headers on token request responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased](https://github.com/axa-group/oauth2-mock-server/compare/v1.0.0...HEAD)
+
+### Fixed
+
+- Add missing cache control headers on `/token` responses
+
 ## 1.0.0 — 2018-08-01
 
 Initial release.

--- a/lib/oauth2-service.js
+++ b/lib/oauth2-service.js
@@ -107,6 +107,11 @@ class OAuth2Service {
   [tokenHandler](req, res) {
     const tokenTtl = 3600;
   
+    res.set({
+      'Cache-Control': 'no-store',
+      'Pragma': 'no-cache'
+    });
+
     if (req.body.grant_type != 'client_credentials') {
       return res.status(400).json({
         error: 'invalid_grant'

--- a/test/oauth2-service.test.js
+++ b/test/oauth2-service.test.js
@@ -52,9 +52,7 @@ describe('OAuth 2 service', () => {
   });
 
   it('should expose a token endpoint that handles Client Credentials grants', async () => {
-    let res = await request(service.requestHandler)
-      .post('/token')
-      .type('form')
+    let res = await tokenRequest(service.requestHandler)
       .send({
         grant_type: 'client_credentials',
         scope: 'urn:first-scope urn:second-scope'
@@ -81,9 +79,7 @@ describe('OAuth 2 service', () => {
     [ 'password' ],
     [ 'INVALID_GRANT_TYPE' ],
   ])('should not handle token requests for grants different than Client Credentials', async (grantType) => {
-    let res = await request(service.requestHandler)
-      .post('/token')
-      .type('form')
+    let res = await tokenRequest(service.requestHandler)
       .send({
         grant_type: grantType
       })
@@ -94,3 +90,11 @@ describe('OAuth 2 service', () => {
     });
   });
 });
+
+function tokenRequest(app) {
+  return request(app)
+    .post('/token')
+    .type('form')
+    .expect('Cache-Control', 'no-store')
+    .expect('Pragma', 'no-cache');
+}


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

Adds the following headers to all `/token` responses:

```http
Cache-Control: no-store
Pragma: no-cache
```

as per [RFC 6749, section 5](https://tools.ietf.org/html/rfc6749#section-5).