### PR TITLE
Implement authorization_code grant and customize responses

### DIFF
--- a/lib/oauth2-issuer.js
+++ b/lib/oauth2-issuer.js
@@ -21,6 +21,7 @@
 'use strict';
 
 const jwt = require('jsonwebtoken');
+const { EventEmitter } = require('events');
 const JWKStore = require('./jwk-store');
 
 const keys = Symbol('keys');
@@ -28,11 +29,12 @@ const keys = Symbol('keys');
 /**
  * Represents an OAuth 2 issuer.
  */
-class OAuth2Issuer {
+class OAuth2Issuer extends EventEmitter {
   /**
    * Creates a new instance of HttpServer.
    */
   constructor() {
+    super();
     /**
      * Sets or returns the issuer URL.
      * @type {String}
@@ -88,12 +90,17 @@ class OAuth2Issuer {
       scopesOrTransform(header, payload);
     }
 
+    const token = {
+      header,
+      payload,
+    };
+    this.emit('beforeSigning', token);
     const options = {
       algorithm: ((arguments.length === 0 || signed) ? getKeyAlg(key) : 'none'),
-      header,
+      header: token.header,
     };
 
-    return jwt.sign(payload, getSecret(key), options);
+    return jwt.sign(token.payload, getSecret(key), options);
   }
 }
 

--- a/lib/oauth2-server.js
+++ b/lib/oauth2-server.js
@@ -27,6 +27,7 @@ const OAuth2Issuer = require('./oauth2-issuer');
 const OAuth2Service = require('./oauth2-service');
 
 const issuer = Symbol('issuer');
+const service = Symbol('service');
 
 /**
  * Represents an OAuth2 HTTP server.
@@ -37,11 +38,12 @@ class OAuth2Server extends HttpServer {
    */
   constructor() {
     const iss = new OAuth2Issuer();
-    const service = new OAuth2Service(iss);
+    const serv = new OAuth2Service(iss);
 
-    super(service.requestHandler);
+    super(serv.requestHandler);
 
     this[issuer] = iss;
+    this[service] = serv;
   }
 
   /**
@@ -50,6 +52,14 @@ class OAuth2Server extends HttpServer {
    */
   get issuer() {
     return this[issuer];
+  }
+
+  /**
+   * Returns the OAuth2Service instance used by the server.
+   * @type {OAuth2Service}
+   */
+  get service() {
+    return this[service];
   }
 
   /**

--- a/lib/oauth2-service.js
+++ b/lib/oauth2-service.js
@@ -22,10 +22,15 @@
 
 const express = require('express');
 const bodyParser = require('body-parser');
+const basicAuth = require('basic-auth');
+const { EventEmitter } = require('events');
+const uuidv4 = require('uuid').v4;
 
 const OPENID_CONFIGURATION_PATH = '/.well-known/openid-configuration';
 const TOKEN_ENDPOINT_PATH = '/token';
 const JWKS_URI_PATH = '/jwks';
+const AUTHORIZE_PATH = '/authorize';
+const USERINFO_PATH = '/userinfo';
 
 const issuer = Symbol('issuer');
 const requestHandler = Symbol('requestHandler');
@@ -34,17 +39,20 @@ const buildRequestHandler = Symbol('buildRequestHandler');
 const openidConfigurationHandler = Symbol('openidConfigurationHandler');
 const jwksHandler = Symbol('jwksHandler');
 const tokenHandler = Symbol('tokenHandler');
+const authorizeHandler = Symbol('authorizeHandler');
+const userInfoHandler = Symbol('userInfoHandler');
 
 /**
  * Provides a request handler for an OAuth 2 server.
  */
-class OAuth2Service {
+class OAuth2Service extends EventEmitter {
   /**
    * Creates a new instance of OAuth2Server.
    * @param {OAuth2Issuer} oauth2Issuer The OAuth2Issuer instance
    *     that will be offered through the service.
    */
   constructor(oauth2Issuer) {
+    super();
     this[issuer] = oauth2Issuer;
 
     this[requestHandler] = this[buildRequestHandler]();
@@ -87,6 +95,8 @@ class OAuth2Service {
     app.post(TOKEN_ENDPOINT_PATH,
       bodyParser.urlencoded({ extended: false }),
       this[tokenHandler].bind(this));
+    app.get(AUTHORIZE_PATH, OAuth2Service[authorizeHandler]);
+    app.get(USERINFO_PATH, this[userInfoHandler].bind(this));
 
     return app;
   }
@@ -95,10 +105,15 @@ class OAuth2Service {
     const openidConfig = {
       issuer: this.issuer.url,
       token_endpoint: `${this.issuer.url}${TOKEN_ENDPOINT_PATH}`,
+      authorization_endpoint: `${this.issuer.url}${AUTHORIZE_PATH}`,
+      userinfo_endpoint: `${this.issuer.url}${USERINFO_PATH}`,
       token_endpoint_auth_methods_supported: ['none'],
       jwks_uri: `${this.issuer.url}${JWKS_URI_PATH}`,
       response_types_supported: ['code'],
-      grant_types_supported: ['client_credentials', 'password'],
+      grant_types_supported: ['client_credentials', 'authorization_code', 'password'],
+      token_endpoint_auth_signing_alg_values_supported: ['RS256'],
+      response_modes_supported: ['query'],
+      id_token_signing_alg_values_supported: ['RS256'],
     };
 
     return res.json(openidConfig);
@@ -117,17 +132,38 @@ class OAuth2Service {
     });
 
     let xfn;
+    let { scope } = req.body;
 
     switch (req.body.grant_type) {
       case 'client_credentials':
-        xfn = req.body.scope;
+        xfn = scope;
         break;
       case 'password':
         xfn = (header, payload) => {
           Object.assign(payload, {
             sub: req.body.username,
             amr: ['pwd'],
-            scope: req.body.scope,
+            scope,
+          });
+        };
+        break;
+      case 'authorization_code':
+        scope = 'dummy';
+        xfn = (header, payload) => {
+          Object.assign(payload, {
+            sub: 'johndoe',
+            amr: ['pwd'],
+            scope,
+          });
+        };
+        break;
+      case 'refresh_token':
+        scope = 'dummy';
+        xfn = (header, payload) => {
+          Object.assign(payload, {
+            sub: 'johndoe',
+            amr: ['pwd'],
+            scope,
           });
         };
         break;
@@ -138,16 +174,55 @@ class OAuth2Service {
     }
 
     const token = this.buildToken(true, xfn, tokenTtl);
-
-    const resp = {
+    const body = {
       access_token: token,
       token_type: 'Bearer',
       expires_in: tokenTtl,
-      scope: req.body.scope,
+      scope,
     };
+    if (req.body.grant_type !== 'client_credentials') {
+      const credentials = basicAuth(req);
+      const clientId = credentials ? credentials.name : null;
+      body.id_token = this.buildToken(true, (header, payload) => {
+        Object.assign(payload, {
+          sub: 'johndoe',
+          aud: clientId,
+        });
+      }, tokenTtl);
+      body.refresh_token = uuidv4();
+    }
+    const tokenEndpointResponse = {
+      body,
+      statusCode: 200,
+    };
+    this.emit('beforeResponse', tokenEndpointResponse);
 
-    return res.json(resp);
+    return res.status(tokenEndpointResponse.statusCode).json(tokenEndpointResponse.body);
+  }
+
+  static [authorizeHandler](req, res) {
+    const { scope, state } = req.query;
+    const responseType = req.query.response_type;
+    const redirectUri = req.query.redirect_uri;
+    const code = uuidv4();
+
+    let targetRedirection = `${redirectUri}?code=${encodeURIComponent(code)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}`;
+    if (responseType !== 'code') {
+      targetRedirection = `${redirectUri}?error=unsupported_response_type&error_description=The+authorization+server+does+not+support+obtaining+an+access+token+using+this+response_type.&state=${encodeURIComponent(state)}`;
+    }
+
+    res.redirect(targetRedirection);
+  }
+
+  [userInfoHandler](req, res) {
+    const userInfoResponse = {
+      body: {
+        sub: 'johndoe',
+      },
+      statusCode: 200,
+    };
+    this.emit('beforeUserinfo', userInfoResponse);
+    res.status(userInfoResponse.statusCode).json(userInfoResponse.body);
   }
 }
-
 module.exports = OAuth2Service;

--- a/package-lock.json
+++ b/package-lock.json
@@ -849,6 +849,14 @@
       "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
       "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A=="
     },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",

--- a/package.json
+++ b/package.json
@@ -33,10 +33,12 @@
     "test": "npm run jest"
   },
   "dependencies": {
+    "basic-auth": "^2.0.1",
     "body-parser": "^1.18.3",
     "express": "^4.16.4",
     "jsonwebtoken": "^8.4.0",
-    "node-jose": "^1.1.0"
+    "node-jose": "^1.1.0",
+    "uuid": "^3.3.2"
   },
   "devDependencies": {
     "eslint": "^5.11.0",

--- a/test/oauth2-issuer.test.js
+++ b/test/oauth2-issuer.test.js
@@ -97,6 +97,21 @@ describe('OAuth 2 issuer', () => {
     expect(decoded.header.x5t).toEqual('a-new-value');
     expect(decoded.payload.sub).toEqual('the-subject');
   });
+
+  it('should be able to modify the header and the payload through a beforeSigning event', () => {
+    issuer.once('beforeSigning', (token) => {
+      /* eslint-disable no-param-reassign */
+      token.header.x5t = 'a-new-value';
+      token.payload.sub = 'the-subject';
+      /* eslint-enable no-param-reassign */
+    });
+
+    const token = issuer.buildToken(true, 'test-rsa-key');
+    const decoded = jwt.decode(token, { complete: true });
+
+    expect(decoded.header.x5t).toEqual('a-new-value');
+    expect(decoded.payload.sub).toEqual('the-subject');
+  });
 });
 
 function getSecret(key) {

--- a/test/oauth2-server.test.js
+++ b/test/oauth2-server.test.js
@@ -25,4 +25,10 @@ describe('OAuth 2 Server', () => {
 
     await expect(server.stop());
   });
+
+  it('should expose the oauth2 service', () => {
+    const server = new OAuth2Server();
+
+    expect(server.service).toBeDefined();
+  });
 });

--- a/test/oauth2-service.test.js
+++ b/test/oauth2-service.test.js
@@ -27,10 +27,15 @@ describe('OAuth 2 service', () => {
     expect(res.body).toMatchObject({
       issuer: url,
       token_endpoint: `${url}/token`,
+      authorization_endpoint: `${url}/authorize`,
+      userinfo_endpoint: `${url}/userinfo`,
       token_endpoint_auth_methods_supported: ['none'],
       jwks_uri: `${url}/jwks`,
       response_types_supported: ['code'],
-      grant_types_supported: ['client_credentials', 'password'],
+      grant_types_supported: ['client_credentials', 'authorization_code', 'password'],
+      token_endpoint_auth_signing_alg_values_supported: ['RS256'],
+      response_modes_supported: ['query'],
+      id_token_signing_alg_values_supported: ['RS256'],
     });
   });
 
@@ -90,6 +95,7 @@ describe('OAuth 2 service', () => {
       token_type: 'Bearer',
       expires_in: 3600,
       scope: 'urn:first-scope urn:second-scope',
+      refresh_token: expect.any(String),
     });
 
     const key = service.issuer.keys.get('test-rsa-key');
@@ -104,18 +110,161 @@ describe('OAuth 2 service', () => {
     });
   });
 
-  it.each([
-    ['authorization_code'],
-    ['INVALID_GRANT_TYPE'],
-  ])('should not handle token requests unsupported grant types', async (grantType) => {
+  it('should expose a token endpoint that handles authorization_code grants', async () => {
+    const res = await request(service.requestHandler)
+      .post('/token')
+      .type('form')
+      .set('authorization', `Basic ${Buffer.from('dummy_client_id:dummy_client_secret').toString('base64')}`)
+      .send({
+        grant_type: 'authorization_code',
+        code: '6b575dd1-2c3b-4284-81b1-e281138cdbbd',
+        redirect_uri: 'https://example.com/callback',
+      })
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      access_token: expect.any(String),
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: 'dummy',
+      id_token: expect.any(String),
+      refresh_token: expect.any(String),
+    });
+
+    const key = service.issuer.keys.get('test-rsa-key');
+
+    const decoded = jwt.verify(res.body.access_token, key.toPEM(false));
+
+    expect(decoded).toMatchObject({
+      iss: service.issuer.url,
+      scope: 'dummy',
+      sub: 'johndoe',
+      amr: ['pwd'],
+    });
+  });
+
+  it('should expose a token endpoint that handles refresh_token grants', async () => {
+    const res = await request(service.requestHandler)
+      .post('/token')
+      .type('form')
+      .set('authorization', `Basic ${Buffer.from('dummy_client_id:dummy_client_secret').toString('base64')}`)
+      .send({
+        grant_type: 'refresh_token',
+        refresh_token: '6b575dd1-2c3b-4284-81b1-e281138cdbbd',
+      })
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      access_token: expect.any(String),
+      token_type: 'Bearer',
+      expires_in: 3600,
+      scope: 'dummy',
+      id_token: expect.any(String),
+      refresh_token: expect.any(String),
+    });
+
+    const key = service.issuer.keys.get('test-rsa-key');
+
+    const decoded = jwt.verify(res.body.access_token, key.toPEM(false));
+
+    expect(decoded).toMatchObject({
+      iss: service.issuer.url,
+      scope: 'dummy',
+      sub: 'johndoe',
+      amr: ['pwd'],
+    });
+  });
+
+  it('should redirect to callback url keeping state when calling authorize endpoint with code response type', async () => {
+    const res = await request(service.requestHandler)
+      .get('/authorize')
+      .query('response_type=code&redirect_uri=http://example.com/callback&scope=dummy_scope&state=state123&client_id=abcecedf')
+      .redirects(0)
+      .expect(302);
+
+    expect(res.headers.location).toMatch(/http:\/\/example\.com\/callback\?code=[^&]*&scope=dummy_scope&state=state123/);
+  });
+
+  it('should redirect to callback url with an error and keeping state when calling authorize endpoint with an invalid response type', async () => {
+    const res = await request(service.requestHandler)
+      .get('/authorize')
+      .query('response_type=invalid_response_type&redirect_uri=http://example.com/callback&scope=dummy_scope&state=state123&client_id=abcecedf')
+      .redirects(0)
+      .expect(302);
+
+    expect(res.headers.location).toMatch('http://example.com/callback?error=unsupported_response_type&error_description=The+authorization+server+does+not+support+obtaining+an+access+token+using+this+response_type.&state=state123');
+  });
+
+  it('should not handle token requests unsupported grant types', async () => {
     const res = await tokenRequest(service.requestHandler)
       .send({
-        grant_type: grantType,
+        grant_type: 'INVALID_GRANT_TYPE',
       })
       .expect(400);
 
     expect(res.body).toMatchObject({
       error: 'invalid_grant',
+    });
+  });
+
+  it('should be able to transform the token endpoint response', async () => {
+    service.once('beforeResponse', (tokenEndpointResponse) => {
+      /* eslint-disable no-param-reassign */
+      tokenEndpointResponse.body.expires_in = 9000;
+      tokenEndpointResponse.body.some_stuff = 'whatever';
+      tokenEndpointResponse.statusCode = 302;
+      /* eslint-enable no-param-reassign */
+    });
+
+    const res = await request(service.requestHandler)
+      .post('/token')
+      .type('form')
+      .set('authorization', `Basic ${Buffer.from('dummy_client_id:dummy_client_secret').toString('base64')}`)
+      .send({
+        grant_type: 'authorization_code',
+        code: '6b575dd1-2c3b-4284-81b1-e281138cdbbd',
+        redirect_uri: 'https://example.com/callback',
+      })
+      .expect(302);
+
+    expect(res.body).toMatchObject({
+      access_token: expect.any(String),
+      token_type: 'Bearer',
+      expires_in: 9000,
+      scope: 'dummy',
+      id_token: expect.any(String),
+      refresh_token: expect.any(String),
+      some_stuff: 'whatever',
+    });
+  });
+
+  it('should expose the userinfo endpoint', async () => {
+    const res = await request(service.requestHandler)
+      .get('/userinfo')
+      .expect(200);
+
+    expect(res.body).toMatchObject({
+      sub: 'johndoe',
+    });
+  });
+
+  it('should allow customizing the userinfo response through a beforeUserinfo event', async () => {
+    service.once('beforeUserinfo', (userInfoResponse) => {
+      /* eslint-disable no-param-reassign */
+      userInfoResponse.body = {
+        error: 'invalid_token',
+        error_message: 'token is expired',
+      };
+      userInfoResponse.statusCode = 401;
+      /* eslint-enable no-param-reassign */
+    });
+    const res = await request(service.requestHandler)
+      .get('/userinfo')
+      .expect(401);
+
+    expect(res.body).toMatchObject({
+      error: 'invalid_token',
+      error_message: 'token is expired',
     });
   });
 });


### PR DESCRIPTION
Implement authorization_code grant and userinfo endpoints and enable customizing the JWT access token, token endpoint and userinfo responses through event emitters.

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

This change provides an authorization_code and userinfo endpoint. It also provides a mean to customize the behavior of the oidc server in a convenient way, through event emitters.
This allows testing not only a resource server (namely an API) but also an express server that manages the user sesssion through passport and openid-client strategy.
It helps making sure that it can properly authenticate a user, protect private endpoints, refresh the token and respond correctly when the refresh_token has expired or has been revoked.