### PR TITLE
Added audience to client_crendentials access token

### DIFF
--- a/lib/oauth2-service.js
+++ b/lib/oauth2-service.js
@@ -137,10 +137,17 @@ class OAuth2Service extends EventEmitter {
 
     let xfn;
     let { scope } = req.body;
+    const credentials = basicAuth(req);
+    const clientId = credentials ? credentials.name : null;
 
     switch (req.body.grant_type) {
       case 'client_credentials':
-        xfn = scope;
+        xfn = (header, payload) => {
+          Object.assign(payload, {
+            aud: clientId,
+            scope,
+          });
+        };
         break;
       case 'password':
         xfn = (header, payload) => {
@@ -185,8 +192,6 @@ class OAuth2Service extends EventEmitter {
       scope,
     };
     if (req.body.grant_type !== 'client_credentials') {
-      const credentials = basicAuth(req);
-      const clientId = credentials ? credentials.name : null;
       body.id_token = this.buildToken(true, (header, payload) => {
         Object.assign(payload, {
           sub: 'johndoe',


### PR DESCRIPTION
## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

I open this PR per @acasella recommendation.

The PR add support to expose the **clientId** when requesting an **access_token** with basic authentication using **client_crendentials** as grant_type.
