### PR TITLE
Add nonce support

### DIFF
--- a/lib/oauth2-service.js
+++ b/lib/oauth2-service.js
@@ -45,6 +45,8 @@ const authorizeHandler = Symbol('authorizeHandler');
 const userInfoHandler = Symbol('userInfoHandler');
 const revokeHandler = Symbol('revokeHandler');
 
+const nonce = Symbol('nonce');
+
 /**
  * Provides a request handler for an OAuth 2 server.
  */
@@ -59,6 +61,8 @@ class OAuth2Service extends EventEmitter {
     this[issuer] = oauth2Issuer;
 
     this[requestHandler] = this[buildRequestHandler]();
+
+    this[nonce] = null;
   }
 
   /**
@@ -112,7 +116,7 @@ class OAuth2Service extends EventEmitter {
     app.post(TOKEN_ENDPOINT_PATH,
       bodyParser.urlencoded({ extended: false }),
       this[tokenHandler].bind(this));
-    app.get(AUTHORIZE_PATH, OAuth2Service[authorizeHandler]);
+    app.get(AUTHORIZE_PATH, this[authorizeHandler].bind(this));
     app.get(USERINFO_PATH, this[userInfoHandler].bind(this));
     app.post(REVOKE_PATH, this[revokeHandler].bind(this));
 
@@ -207,6 +211,12 @@ class OAuth2Service extends EventEmitter {
           sub: 'johndoe',
           aud: clientId,
         });
+        if (this[nonce]) {
+          Object.assign(payload, {
+            nonce: this[nonce],
+          });
+          this[nonce] = null;
+        }
       }, tokenTtl, req);
       body.refresh_token = uuidv4();
     }
@@ -228,14 +238,19 @@ class OAuth2Service extends EventEmitter {
     return res.status(tokenEndpointResponse.statusCode).json(tokenEndpointResponse.body);
   }
 
-  static [authorizeHandler](req, res) {
+  [authorizeHandler](req, res) {
     const { scope, state } = req.query;
     const responseType = req.query.response_type;
     const redirectUri = req.query.redirect_uri;
     const code = uuidv4();
 
-    let targetRedirection = `${redirectUri}?code=${encodeURIComponent(code)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}`;
-    if (responseType !== 'code') {
+    let targetRedirection;
+    if (responseType === 'code') {
+      if (req.query.nonce) {
+        this[nonce] = req.query.nonce;
+      }
+      targetRedirection = `${redirectUri}?code=${encodeURIComponent(code)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}`;
+    } else {
       targetRedirection = `${redirectUri}?error=unsupported_response_type&error_description=The+authorization+server+does+not+support+obtaining+an+access+token+using+this+response_type.&state=${encodeURIComponent(state)}`;
     }
 

--- a/lib/oauth2-service.js
+++ b/lib/oauth2-service.js
@@ -62,7 +62,7 @@ class OAuth2Service extends EventEmitter {
 
     this[requestHandler] = this[buildRequestHandler]();
 
-    this[nonce] = null;
+    this[nonce] = {};
   }
 
   /**
@@ -211,11 +211,11 @@ class OAuth2Service extends EventEmitter {
           sub: 'johndoe',
           aud: clientId,
         });
-        if (this[nonce]) {
+        if (this[nonce][req.body.code]) {
           Object.assign(payload, {
-            nonce: this[nonce],
+            nonce: this[nonce][req.body.code],
           });
-          this[nonce] = null;
+          delete this[nonce][req.body.code];
         }
       }, tokenTtl, req);
       body.refresh_token = uuidv4();
@@ -247,7 +247,7 @@ class OAuth2Service extends EventEmitter {
     let targetRedirection;
     if (responseType === 'code') {
       if (req.query.nonce) {
-        this[nonce] = req.query.nonce;
+        this[nonce][code] = req.query.nonce;
       }
       targetRedirection = `${redirectUri}?code=${encodeURIComponent(code)}&scope=${encodeURIComponent(scope)}&state=${encodeURIComponent(state)}`;
     } else {

--- a/test/oauth2-service.test.js
+++ b/test/oauth2-service.test.js
@@ -217,7 +217,7 @@ describe('OAuth 2 service', () => {
   });
 
   it('should expose a token endpoint that remembers nonce', async () => {
-    await request(service.requestHandler)
+    const resAuth = await request(service.requestHandler)
       .get('/authorize')
       .query('response_type=code&redirect_uri=http://example.com/callback&scope=dummy_scope&state=state123&client_id=abcecedf&nonce=21ba8e4a-26af-4538-b98a-bccf031f6754');
 
@@ -226,7 +226,38 @@ describe('OAuth 2 service', () => {
       .type('form')
       .send({
         grant_type: 'authorization_code',
-        code: '6b575dd1-2c3b-4284-81b1-e281138cdbbd',
+        code: getCode(resAuth),
+        redirect_uri: 'https://example.com/callback',
+        client_id: 'abcecedf',
+      })
+      .expect(200);
+
+    const key = service.issuer.keys.get('test-rsa-key');
+
+    const decoded = jwt.verify(res.body.id_token, key.toPEM(false));
+
+    expect(decoded).toMatchObject({
+      sub: 'johndoe',
+      aud: 'abcecedf',
+      nonce: '21ba8e4a-26af-4538-b98a-bccf031f6754',
+    });
+  });
+
+  it('should expose a token endpoint that remembers nonces of multiple clients', async () => {
+    const resAuth = await request(service.requestHandler)
+      .get('/authorize')
+      .query('response_type=code&redirect_uri=http://example.com/callback&scope=dummy_scope&state=state123&client_id=abcecedf&nonce=21ba8e4a-26af-4538-b98a-bccf031f6754');
+
+    await request(service.requestHandler)
+      .get('/authorize')
+      .query('response_type=code&redirect_uri=http://example.com/callback&scope=dummy_scope&state=state456&client_id=abcecedf&nonce=7184422e-f260-11ea-adc1-0242ac120002');
+
+    const res = await request(service.requestHandler)
+      .post('/token')
+      .type('form')
+      .send({
+        grant_type: 'authorization_code',
+        code: getCode(resAuth),
         redirect_uri: 'https://example.com/callback',
         client_id: 'abcecedf',
       })
@@ -452,6 +483,13 @@ describe('OAuth 2 service', () => {
     expect(res.headers['access-control-allow-origin']).toBe('*');
   });
 });
+
+function getCode(response) {
+  const parts = response.header.location.split('?', 2);
+  return parts[1].split('&')
+    .find((query) => query.startsWith('code='))
+    .split('=', 2)[1];
+}
 
 function tokenRequest(app) {
   return request(app)


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

The PR adds nonce support to mock OIDC authentication server.
`authorizeHandler()` changed to be non-static in order to store nonce values in the server's state.