### PR TITLE
Add subject type supported

### DIFF
--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -161,6 +161,7 @@ export class OAuth2Service extends EventEmitter {
       response_modes_supported: ['query'],
       id_token_signing_alg_values_supported: ['RS256'],
       revocation_endpoint: `${this.issuer.url}${REVOKE_PATH}`,
+      subject_types_supported: ['public'],
     };
 
     return res.json(openidConfig);

--- a/test/oauth2-service.test.ts
+++ b/test/oauth2-service.test.ts
@@ -40,6 +40,7 @@ describe('OAuth 2 service', () => {
       response_modes_supported: ['query'],
       id_token_signing_alg_values_supported: ['RS256'],
       revocation_endpoint: `${url!}/revoke`,
+      subject_types_supported: ['public'],
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

The latest OpenID spec requires the subject_type_supported field to be provided on the open ID well-known metadata.  https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata

Some libraries (e.g. pac4j in the java ecosystem) rely on this standard and will not work without the required spec.

This PR adds a value of 'public' which has always been the default value for when there is no array provided:
https://openid.net/specs/openid-connect-core-1_0.html#SubjectIDTypes

Future PR's might support the addition of 'pairwise' identifiers, but given this was not in the project previously this should be backwards compatible.
