### PR TITLE
Cope with unhandled rejected promises in /token handler

### DIFF
--- a/test/oauth2-server.test.ts
+++ b/test/oauth2-server.test.ts
@@ -39,4 +39,19 @@ describe('OAuth 2 Server', () => {
       new OAuth2Server(undefined, "test/keys/localhost-cert.pem");
     }).toThrow();
   });
+
+  it('should not raise an UnhandledPromiseRejectionWarning when wrongly invoking the /token endpoint', async () => {
+    const server = new OAuth2Server();
+
+    await expect(server.start()).resolves.not.toThrow();
+
+    const host = `http://127.0.0.1:${server.address().port}`;
+    const res = await request(host)
+      .post('/token')
+      .set('Content-Type', 'multipart/form-data;');
+
+    expect(res.text).toContain("[ERR_ASSERTION]: Invalid &#39;grant_type&#39; type");
+
+    await expect(server.stop()).resolves.not.toThrow();
+  });
 });


### PR DESCRIPTION
Fix #141 

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Express 4.x doesn't properly cope with rejected promises by default.
Delegating to next() invokes the standard error handler.