### PR TITLE
Add support for custom endpoint pathnames

### DIFF
--- a/src/lib/oauth2-server.ts
+++ b/src/lib/oauth2-server.ts
@@ -27,7 +27,7 @@ import { HttpServer } from './http-server';
 import { OAuth2Issuer } from './oauth2-issuer';
 import { OAuth2Service } from './oauth2-service';
 import { assertIsAddressInfo } from './helpers';
-import { HttpServerOptions } from './types';
+import { HttpServerOptions, OAuth2Options } from './types';
 
 /**
  * Represents an OAuth2 HTTP server.
@@ -41,14 +41,15 @@ export class OAuth2Server extends HttpServer {
    *
    * @param {string | undefined} key Optional key file path for ssl
    * @param {string | undefined} cert Optional cert file path for ssl
+   * @param {OAuth2Options | undefined} oauth2Options Optional additional settings
    */
-  constructor(key?: string, cert?: string) {
+  constructor(key?: string, cert?: string, oauth2Options?: OAuth2Options) {
     if ((key && !cert) || (!key && cert)) {
       throw 'Both key and cert need to be supplied to start the server with https';
     }
 
     const iss = new OAuth2Issuer();
-    const serv = new OAuth2Service(iss);
+    const serv = new OAuth2Service(iss, oauth2Options?.endpoints);
 
     let options: HttpServerOptions | undefined = undefined;
     if (key && cert) {

--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -37,19 +37,33 @@ import type {
   MutableRedirectUri,
   MutableResponse,
   MutableToken,
+  OAuth2Endpoints,
   ScopesOrTransform,
   StatusCodeMutableResponse,
 } from './types';
 import { Events } from './types';
 import { InternalEvents } from './types-internals';
 
-const OPENID_CONFIGURATION_PATH = '/.well-known/openid-configuration';
-const TOKEN_ENDPOINT_PATH = '/token';
-const JWKS_URI_PATH = '/jwks';
-const AUTHORIZE_PATH = '/authorize';
-const USERINFO_PATH = '/userinfo';
-const REVOKE_PATH = '/revoke';
-const END_SESSION_ENDPOINT_PATH = '/endsession';
+// same as 'OAuth2Endpoints' but all paths required
+interface OAuth2AllEndpoints {
+  wellKnownDocument: string;
+  token: string;
+  jwks: string;
+  authorize: string;
+  userinfo: string;
+  revoke: string;
+  endSession: string;
+}
+
+const DEFAULT_ENDPOINTS: OAuth2AllEndpoints = Object.freeze({
+  wellKnownDocument: '/.well-known/openid-configuration',
+  token: '/token',
+  jwks: '/jwks',
+  authorize: '/authorize',
+  userinfo: '/userinfo',
+  revoke: '/revoke',
+  endSession: '/endsession',
+});
 
 /**
  * Provides a request handler for an OAuth 2 server.
@@ -60,16 +74,19 @@ export class OAuth2Service extends EventEmitter {
    *
    * @param {OAuth2Issuer} oauth2Issuer The OAuth2Issuer instance
    *     that will be offered through the service.
+   * @param {OAuth2Endpoints | undefined} paths Endpoint path name overrides.
    */
 
   #issuer: OAuth2Issuer;
   #requestHandler: Express;
   #nonce: Record<string, string>;
+  #endpoints: OAuth2AllEndpoints;
 
-  constructor(oauth2Issuer: OAuth2Issuer) {
+  constructor(oauth2Issuer: OAuth2Issuer, endpoints?: OAuth2Endpoints) {
     super();
     this.#issuer = oauth2Issuer;
 
+    this.#endpoints = { ...DEFAULT_ENDPOINTS, ...endpoints };
     this.#requestHandler = this.buildRequestHandler();
 
     this.#nonce = {};
@@ -126,17 +143,17 @@ export class OAuth2Service extends EventEmitter {
     const app = express();
     app.disable('x-powered-by');
     app.use(cors());
-    app.get(OPENID_CONFIGURATION_PATH, this.openidConfigurationHandler);
-    app.get(JWKS_URI_PATH, this.jwksHandler);
+    app.get(this.#endpoints.wellKnownDocument, this.openidConfigurationHandler);
+    app.get(this.#endpoints.jwks, this.jwksHandler);
     app.post(
-      TOKEN_ENDPOINT_PATH,
+      this.#endpoints.token,
       express.urlencoded({ extended: false }),
       this.tokenHandler
     );
-    app.get(AUTHORIZE_PATH, this.authorizeHandler);
-    app.get(USERINFO_PATH, this.userInfoHandler);
-    app.post(REVOKE_PATH, this.revokeHandler);
-    app.get(END_SESSION_ENDPOINT_PATH, this.endSessionHandler);
+    app.get(this.#endpoints.authorize, this.authorizeHandler);
+    app.get(this.#endpoints.userinfo, this.userInfoHandler);
+    app.post(this.#endpoints.revoke, this.revokeHandler);
+    app.get(this.#endpoints.endSession, this.endSessionHandler);
 
     return app;
   };
@@ -146,11 +163,11 @@ export class OAuth2Service extends EventEmitter {
 
     const openidConfig = {
       issuer: this.issuer.url,
-      token_endpoint: `${this.issuer.url}${TOKEN_ENDPOINT_PATH}`,
-      authorization_endpoint: `${this.issuer.url}${AUTHORIZE_PATH}`,
-      userinfo_endpoint: `${this.issuer.url}${USERINFO_PATH}`,
+      token_endpoint: `${this.issuer.url}${this.#endpoints.token}`,
+      authorization_endpoint: `${this.issuer.url}${this.#endpoints.authorize}`,
+      userinfo_endpoint: `${this.issuer.url}${this.#endpoints.userinfo}`,
       token_endpoint_auth_methods_supported: ['none'],
-      jwks_uri: `${this.issuer.url}${JWKS_URI_PATH}`,
+      jwks_uri: `${this.issuer.url}${this.#endpoints.jwks}`,
       response_types_supported: ['code'],
       grant_types_supported: [
         'client_credentials',
@@ -160,9 +177,9 @@ export class OAuth2Service extends EventEmitter {
       token_endpoint_auth_signing_alg_values_supported: ['RS256'],
       response_modes_supported: ['query'],
       id_token_signing_alg_values_supported: ['RS256'],
-      revocation_endpoint: `${this.issuer.url}${REVOKE_PATH}`,
+      revocation_endpoint: `${this.issuer.url}${this.#endpoints.revoke}`,
       subject_types_supported: ['public'],
-      end_session_endpoint: `${this.issuer.url}${END_SESSION_ENDPOINT_PATH}`,
+      end_session_endpoint: `${this.issuer.url}${this.#endpoints.endSession}`,
     };
 
     return res.json(openidConfig);

--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -38,24 +38,14 @@ import type {
   MutableResponse,
   MutableToken,
   OAuth2Endpoints,
+  OAuth2EndpointsInput,
   ScopesOrTransform,
   StatusCodeMutableResponse,
 } from './types';
 import { Events } from './types';
 import { InternalEvents } from './types-internals';
 
-// same as 'OAuth2Endpoints' but all paths required
-interface OAuth2AllEndpoints {
-  wellKnownDocument: string;
-  token: string;
-  jwks: string;
-  authorize: string;
-  userinfo: string;
-  revoke: string;
-  endSession: string;
-}
-
-const DEFAULT_ENDPOINTS: OAuth2AllEndpoints = Object.freeze({
+const DEFAULT_ENDPOINTS: OAuth2Endpoints = Object.freeze({
   wellKnownDocument: '/.well-known/openid-configuration',
   token: '/token',
   jwks: '/jwks',
@@ -74,15 +64,15 @@ export class OAuth2Service extends EventEmitter {
    *
    * @param {OAuth2Issuer} oauth2Issuer The OAuth2Issuer instance
    *     that will be offered through the service.
-   * @param {OAuth2Endpoints | undefined} paths Endpoint path name overrides.
+   * @param {OAuth2EndpointsInput | undefined} paths Endpoint path name overrides.
    */
 
   #issuer: OAuth2Issuer;
   #requestHandler: Express;
   #nonce: Record<string, string>;
-  #endpoints: OAuth2AllEndpoints;
+  #endpoints: OAuth2Endpoints;
 
-  constructor(oauth2Issuer: OAuth2Issuer, endpoints?: OAuth2Endpoints) {
+  constructor(oauth2Issuer: OAuth2Issuer, endpoints?: OAuth2EndpointsInput) {
     super();
     this.#issuer = oauth2Issuer;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -89,15 +89,17 @@ export interface JWK extends JWKWithKid {
 }
 
 export interface OAuth2Endpoints {
-  wellKnownDocument?: string;
-  token?: string;
-  jwks?: string;
-  authorize?: string;
-  userinfo?: string;
-  revoke?: string;
-  endSession?: string;
+  wellKnownDocument: string;
+  token: string;
+  jwks: string;
+  authorize: string;
+  userinfo: string;
+  revoke: string;
+  endSession: string;
 }
 
+export type OAuth2EndpointsInput = Partial<OAuth2Endpoints>;
+
 export interface OAuth2Options {
-  endpoints?: OAuth2Endpoints;
+  endpoints?: OAuth2EndpointsInput;
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -87,3 +87,17 @@ export interface TokenBuildOptions {
 export interface JWK extends JWKWithKid {
   alg: string;
 }
+
+export interface OAuth2Endpoints {
+  wellKnownDocument?: string;
+  token?: string;
+  jwks?: string;
+  authorize?: string;
+  userinfo?: string;
+  revoke?: string;
+  endSession?: string;
+}
+
+export interface OAuth2Options {
+  endpoints?: OAuth2Endpoints;
+}

--- a/test/oauth2-server.test.ts
+++ b/test/oauth2-server.test.ts
@@ -54,4 +54,18 @@ describe('OAuth 2 Server', () => {
 
     await expect(server.stop()).resolves.not.toThrow();
   });
+
+  it('should override custom endpoint pathnames', async () => {
+    const endpoints = { jwks: '/custom-jwks' };
+    const server = new OAuth2Server(undefined, undefined, { endpoints });
+
+    await expect(server.start()).resolves.not.toThrow();
+
+    const host = `http://127.0.0.1:${server.address().port}`;
+    await request(host)
+      .get('/custom-jwks')
+      .expect(200);
+
+    await expect(server.stop()).resolves.not.toThrow();
+  });
 });


### PR DESCRIPTION
## PR Checklist

- [X] I have run `npm test` locally and all tests are passing.
- [X] I have added/updated tests for any new behavior.
- [X] If this is a significant change, an issue has already been created where the problem / solution was discussed: https://github.com/axa-group/oauth2-mock-server/issues/151

## PR Description

Add options object to override default endpoint pathnames to support some OAuth2 clients which have different hardcoded paths

Non-breaking changes