### PR TITLE
Support the token introspection endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,21 @@ It also provides a convenient way, through event emitters, to programmatically c
   });
   ```
 
+- The introspect endpoint response body
+
+  ```js
+  // Simulate a custom token introspection response body
+  service.once('beforeIntrospect', (introspectResponse, req) => {
+    introspectResponse.body = {
+        active: true,
+        scope: "read write email",
+        client_id: "<client_id>",
+        username: "dummy",
+        exp: 1643712575
+      };
+  });
+  ```
+
 ### HTTPS support
 
 It also provides basic HTTPS support, an optional cert and key can be supplied to start the server with SSL/TLS using the in-built NodeJS [HTTPS](https://nodejs.org/api/https.html) module.
@@ -225,6 +240,10 @@ It simulates a token revocation. This endpoint should always return 200 as state
 ### GET `/endsession`
 
 It simulates the end session endpoint. It will automatically redirect to the post_logout_redirect_uri sent as parameter.
+
+### POST `/introspect`
+
+It simulates the [token introspection endpoint](https://www.oauth.com/oauth2-servers/token-introspection-endpoint/).
 
 ## Command-Line Interface
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -64,6 +64,7 @@ export enum Events {
   BeforeRevoke = 'beforeRevoke',
   BeforeAuthorizeRedirect = 'beforeAuthorizeRedirect',
   BeforePostLogoutRedirect = 'beforePostLogoutRedirect',
+  BeforeIntrospect = 'beforeIntrospect',
 }
 
 export interface TokenBuildOptions {
@@ -96,6 +97,7 @@ export interface OAuth2Endpoints {
   userinfo: string;
   revoke: string;
   endSession: string;
+  introspect: string;
 }
 
 export type OAuth2EndpointsInput = Partial<OAuth2Endpoints>;


### PR DESCRIPTION
Fix #160

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here] #160 

## PR Description

Support the token introspection endpoint and the default endpoint is `/introspect`
