### PR TITLE
Fix authorize endpoint compliance - remove scope, make state optional

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -34,6 +34,15 @@ export function assertIsString(
   }
 }
 
+export function assertIsStringOrUndefined(
+  input: unknown,
+  errorMessage: string
+): asserts input is string | undefined {
+  if (typeof input !== 'string' && input !== undefined) {
+    throw new AssertionError({ message: errorMessage });
+  }
+}
+
 export function assertIsAddressInfo(
   input: string | null | AddressInfo
 ): asserts input is AddressInfo {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -4,6 +4,7 @@ import {
   assertIsAddressInfo,
   assertIsPlainObject,
   assertIsString,
+  assertIsStringOrUndefined,
   assertIsValidTokenRequest,
   shift,
 } from '../src/lib/helpers';
@@ -22,6 +23,26 @@ describe('helpers', () => {
 
     it('does not throw on strings', () => {
       expect(() => assertIsString("good", "will not throw")).not.toThrow();
+    });
+  });
+
+  describe('assertIsStringOrUndefined', () => {
+    it.each([
+      null,
+      1,
+      true,
+      {},
+      []
+    ])('throws on wrong types (%s)', (input) => {
+      expect(() => assertIsStringOrUndefined(input, "boom")).toThrow();
+    });
+
+    it('does not throw on strings', () => {
+      expect(() => assertIsStringOrUndefined("good", "will not throw")).not.toThrow();
+    });
+
+    it('does not throw on undefined', () => {
+      expect(() => assertIsStringOrUndefined(undefined, "will not throw")).not.toThrow();
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

The scope parameter is optional in the Authorization Request (Section 4.1.1 and 4.2.1 of [RFC 6749] and Section 3.3.2.1 of [OIDC 1.0 Core]).

Authorization Endpoint does not include the scope parameter in the response when the response type is "code" (Section 4.1.2 of [RFC 6749] and 3.1.2.5 of [OIDC 1.0 Core]).

The state parameter is recommended, but not mandatory, according to (Section 4.1.1 of [RFC 6749] and Section 3.3.2.1 of [OIDC 1.0 Core]).

[RFC 6749]: https://datatracker.ietf.org/doc/html/rfc6749
[OIDC 1.0 Core]: https://openid.net/specs/openid-connect-core-1_0.html