### PR TITLE
Overriding the host returned by the .well-known endpoint via an environment variable (useful when deploying in a container environment) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,12 @@ NOTE: Enabling HTTPS will also update the issuer URL to reflect the current prot
 
 Returns the [OpenID Provider Configuration Information](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderConfig) for the server.
 
+Note by default the hostname used in the .well-known endpoint is the same hostname
+used to start the server.  You can override the hostname returned by the .well-known
+endpoint by setting the `IDP_WELLKNOWN_HOST_OVERRIDE` environment prior to running
+the oAuth server.  This can be useful if you are running the server behind a reverse
+proxy or within a container environment like Kubernetes.
+
 ### GET `/jwks`
 
 Returns the JSON Web Key Set (JWKS) of all the keys configured in the server.

--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -149,13 +149,18 @@ export class OAuth2Service extends EventEmitter {
   private openidConfigurationHandler: RequestHandler = (_req, res) => {
     assertIsString(this.issuer.url, 'Unknown issuer url.');
 
+    const WELL_KNOWN_SERVER =
+      process.env['IDP_WELLKNOWN_HOST_OVERRIDE'] || this.issuer.url;
+
     const openidConfig = {
-      issuer: this.issuer.url,
-      token_endpoint: `${this.issuer.url}${this.#endpoints.token}`,
-      authorization_endpoint: `${this.issuer.url}${this.#endpoints.authorize}`,
-      userinfo_endpoint: `${this.issuer.url}${this.#endpoints.userinfo}`,
+      issuer: WELL_KNOWN_SERVER,
+      token_endpoint: `${WELL_KNOWN_SERVER}${this.#endpoints.token}`,
+      authorization_endpoint: `${WELL_KNOWN_SERVER}${
+        this.#endpoints.authorize
+      }`,
+      userinfo_endpoint: `${WELL_KNOWN_SERVER}${this.#endpoints.userinfo}`,
       token_endpoint_auth_methods_supported: ['none'],
-      jwks_uri: `${this.issuer.url}${this.#endpoints.jwks}`,
+      jwks_uri: `${WELL_KNOWN_SERVER}${this.#endpoints.jwks}`,
       response_types_supported: ['code'],
       grant_types_supported: [
         'client_credentials',
@@ -165,10 +170,12 @@ export class OAuth2Service extends EventEmitter {
       token_endpoint_auth_signing_alg_values_supported: ['RS256'],
       response_modes_supported: ['query'],
       id_token_signing_alg_values_supported: ['RS256'],
-      revocation_endpoint: `${this.issuer.url}${this.#endpoints.revoke}`,
+      revocation_endpoint: `${WELL_KNOWN_SERVER}${this.#endpoints.revoke}`,
       subject_types_supported: ['public'],
-      end_session_endpoint: `${this.issuer.url}${this.#endpoints.endSession}`,
-      introspection_endpoint: `${this.issuer.url}${this.#endpoints.introspect}`,
+      end_session_endpoint: `${WELL_KNOWN_SERVER}${this.#endpoints.endSession}`,
+      introspection_endpoint: `${WELL_KNOWN_SERVER}${
+        this.#endpoints.introspect
+      }`,
     };
 
     return res.json(openidConfig);

--- a/src/oauth2-mock-server.ts
+++ b/src/oauth2-mock-server.ts
@@ -107,6 +107,10 @@ Options:
                     Can be specified many times.
   --save-jwk        Saves all the keys in the keystore as "{kid}.json".
 
+  Setting the environment variable IDP_WELLKNOWN_HOST_OVERRIDE will override
+  the hostname used when hitting the .well-known endpoint.  This might be
+  useful when running behind a reverse proxy or when deploying in kubernetes.
+
 If no keys are added via the --jwk option, a new random RSA key
 will be generated. This key can then be saved to disk with the --save-jwk
 for later reuse.`);


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Describe Your PR Here!
I would like to thank the creators of this package, it fit in perfectly to a project we were doing to support some software engineering research.  Our goal was to use some custom claims in an oAuth JWT to drive some different behaviors we wanted to investigate.

One challenge that we ran into, which we got to work, but required some complex Kubernetes configuration was to enable the oAuth server to be deployed inside of a Kubernetes cluster so that other APIs can validate JWT tokens.  The problem we ran into was the Go library we were using from Auth0, hit the `/.well-known/openid-configuration` endpoint and wasn’t able to get to the `/jwks` endpoint to validate the token since within a Kubernetes pod we started the service with host 0.0.0.0 and used a Kubernetes service to expose the pod to other pods in the cluster.  We were able to work around this within just Kubernetes, however, enabling the well-known host configurable via an environment variable greatly simplified things for us.

This pull request gives back what we did in case you want to include it in your distribution moving forward.  The changes we made were isolated to the `openidConfigurationHandler()` function.  We also updated the `readme.md` documentation, and made a mention of this in the help output rendered by `showHelp()`.

Your call if you want to include this or not, or even more deeply embed this feature within your code - we did not want to modify any of your underlying data structures so this was the easiest way for us to move forward.   
