### PR TITLE
Add support for "aud" claim in "client_credentials" grants

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -74,6 +74,15 @@ export function assertIsValidTokenRequest(
   if ('code' in body) {
     assertIsString(body['code'], "Invalid 'code' type");
   }
+
+  if ('aud' in body) {
+    const aud = body['aud'];
+    if (Array.isArray(aud)) {
+      aud.forEach((a) => assertIsString(a, "Invalid 'aud' type"));
+    } else {
+      assertIsString(aud, "Invalid 'aud' type");
+    }
+  }
 }
 
 export function shift(arr: (string | undefined)[]): string {

--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -193,10 +193,13 @@ export class OAuth2Service extends EventEmitter {
       const reqBody = req.body;
 
       let { scope } = reqBody;
+      const { aud } = reqBody;
 
       switch (req.body.grant_type) {
         case 'client_credentials':
-          xfn = scope;
+          xfn = (_header, payload) => {
+            Object.assign(payload, { scope, aud });
+          };
           break;
         case 'password':
           xfn = (_header, payload) => {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,6 +7,7 @@ export interface TokenRequest {
   username?: unknown;
   client_id?: unknown;
   code?: string;
+  aud?: string[] | string;
 }
 
 export interface Options {

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -96,6 +96,8 @@ describe('helpers', () => {
       { grant_type: "g", scope: 1 },
       { grant_type: "g", scope: "s", code: 1 },
       { grant_type: "g", scope: 1, code: "c" },
+      { grant_type: "g", scope: "1", code: "c", aud: 1 },
+      { grant_type: "g", scope: "1", code: "c", aud: [1] },
     ])('throws on wrong values (%s)', (input) => {
       expect(() => assertIsValidTokenRequest(input)).toThrow();
     });
@@ -105,6 +107,8 @@ describe('helpers', () => {
       { grant_type: "g", code: "c" },
       { grant_type: "g", scope: "s" },
       { grant_type: "g", scope: "s", code: "c" },
+      { grant_type: "g", scope: "s", code: "c", aud: "a" },
+      { grant_type: "g", scope: "s", code: "c", aud: ["a", "b"] },
     ])('does not throw on valid input (%s)', (input) => {
       expect(() => assertIsValidTokenRequest(input)).not.toThrow();
     });

--- a/test/oauth2-service.test.ts
+++ b/test/oauth2-service.test.ts
@@ -152,6 +152,24 @@ describe('OAuth 2 service', () => {
     });
   });
 
+  it('should expose a token endpoint that includes an aud claim on Client Credentials grants', async () => {
+    const res = await tokenRequest(service.requestHandler)
+      .send({
+        grant_type: 'client_credentials',
+        scope: 'urn:first-scope urn:second-scope',
+        aud: 'aud'
+      })
+      .expect(200);
+
+    const resBody = res.body as { access_token: string; scope: string };
+    const decoded = await verifyTokenWithKey(service.issuer, resBody.access_token, 'test-rs256-key');
+
+    expect(decoded.payload).toMatchObject({
+      aud: 'aud',
+    });
+  });
+
+
   it('should expose a token endpoint that handles Resource Owner Password Credentials grants', async () => {
     const res = await request(service.requestHandler)
       .post('/token')

--- a/test/oauth2-service.test.ts
+++ b/test/oauth2-service.test.ts
@@ -152,21 +152,23 @@ describe('OAuth 2 service', () => {
     });
   });
 
-  it('should expose a token endpoint that includes an aud claim on Client Credentials grants', async () => {
+  it.each([
+    'aud',
+    ['aud1', 'aud2']
+  ])('should expose a token endpoint that includes an aud claim on Client Credentials grants', async (aud) => {
     const res = await tokenRequest(service.requestHandler)
+      .type('json')
       .send({
         grant_type: 'client_credentials',
         scope: 'urn:first-scope urn:second-scope',
-        aud: 'aud'
+        aud,
       })
       .expect(200);
 
     const resBody = res.body as { access_token: string; scope: string };
     const decoded = await verifyTokenWithKey(service.issuer, resBody.access_token, 'test-rs256-key');
 
-    expect(decoded.payload).toMatchObject({
-      aud: 'aud',
-    });
+    expect(decoded.payload).toMatchObject({ aud });
   });
 
 

--- a/test/oauth2-service.test.ts
+++ b/test/oauth2-service.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import request from 'supertest';
 import { IncomingMessage, type RequestListener } from 'http';
+import qs from 'querystring';
 
 import { OAuth2Issuer } from '../src/lib/oauth2-issuer';
 import { OAuth2Service } from '../src/lib/oauth2-service';
@@ -157,12 +158,11 @@ describe('OAuth 2 service', () => {
     ['aud1', 'aud2']
   ])('should expose a token endpoint that includes an aud claim on Client Credentials grants', async (aud) => {
     const res = await tokenRequest(service.requestHandler)
-      .type('json')
-      .send({
+      .send(qs.stringify({
         grant_type: 'client_credentials',
         scope: 'urn:first-scope urn:second-scope',
         aud,
-      })
+      }))
       .expect(200);
 
     const resBody = res.body as { access_token: string; scope: string };

--- a/test/oauth2-service.test.ts
+++ b/test/oauth2-service.test.ts
@@ -160,12 +160,11 @@ describe('OAuth 2 service', () => {
     const res = await tokenRequest(service.requestHandler)
       .send(qs.stringify({
         grant_type: 'client_credentials',
-        scope: 'urn:first-scope urn:second-scope',
         aud,
       }))
       .expect(200);
 
-    const resBody = res.body as { access_token: string; scope: string };
+    const resBody = res.body as { access_token: string; };
     const decoded = await verifyTokenWithKey(service.issuer, resBody.access_token, 'test-rs256-key');
 
     expect(decoded.payload).toMatchObject({ aud });


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: N/A

## PR Description

In our environment, we have a lot of integration pipelines, generally set up as Kafka producers/consumers or REST APIs. The Kafka apps (the client) heavily use `client_credentials` grants, as they're acting on their own behalf rather than a particular user. If they're interactive with those internal REST APIs (the resource), then we verify the `aud` claim to make sure a particular token was indeed intended for that particular API.

We'd love to use oauth2-mock-server for our testing, but we need it to support encoding the optional `aud` claim. This PR adds it to the claims being encoded for `client_credentials` grants.

Some resources on the `aud` claim:

- https://stackoverflow.com/questions/28418360/jwt-json-web-token-audience-aud-versus-client-id-whats-the-difference
- https://learn.microsoft.com/en-us/azure/active-directory-b2c/client-credentials-grant-flow?pivots=b2c-user-flow#step-3-obtain-an-access-token
- https://www.oauth.com/oauth2-servers/access-tokens/self-encoded-access-tokens/#encoding
