### PR TITLE
Added scope copy for authorization_code and refresh_token grants.

### DIFF
--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -211,7 +211,7 @@ export class OAuth2Service extends EventEmitter {
           };
           break;
         case 'authorization_code':
-          scope = 'dummy';
+          scope = scope ?? 'dummy';
           xfn = (_header, payload) => {
             Object.assign(payload, {
               sub: 'johndoe',
@@ -221,7 +221,7 @@ export class OAuth2Service extends EventEmitter {
           };
           break;
         case 'refresh_token':
-          scope = 'dummy';
+          scope = scope ?? 'dummy';
           xfn = (_header, payload) => {
             Object.assign(payload, {
               sub: 'johndoe',


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #259

## PR Description

Takes scope from request if available and uses 'dummy' if not. Fixes issue where MSAL library invalidates cache if scope is not matching and therefore requests a new token on every request.