### PR TITLE
fix(#233): make post_logout_redirect_uri optional

### DIFF
--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -378,14 +378,16 @@ export class OAuth2Service extends EventEmitter {
   };
 
   private endSessionHandler: RequestHandler = (req, res) => {
-    assertIsString(
-      req.query['post_logout_redirect_uri'],
-      'Invalid post_logout_redirect_uri type',
-    );
-
-    const postLogoutRedirectUri: MutableRedirectUri = {
-      url: new URL(req.query['post_logout_redirect_uri']),
-    };
+    let postLogoutRedirectUri: MutableRedirectUri | undefined = undefined;
+    if (req.query['post_logout_redirect_uri']) {
+      assertIsString(
+        req.query['post_logout_redirect_uri'],
+        'Invalid post_logout_redirect_uri type',
+      );
+      postLogoutRedirectUri = {
+        url: new URL(req.query['post_logout_redirect_uri']),
+      };
+    }
 
     /**
      * Before post logout redirect event.
@@ -395,7 +397,11 @@ export class OAuth2Service extends EventEmitter {
      */
     this.emit(Events.BeforePostLogoutRedirect, postLogoutRedirectUri, req);
 
-    return res.redirect(postLogoutRedirectUri.url.href);
+    if (postLogoutRedirectUri !== undefined) {
+      return res.redirect(postLogoutRedirectUri.url.href);
+    } else {
+      return res.status(200).send('Logout successful');
+    }
   };
 
   private introspectHandler: RequestHandler = (req, res) => {

--- a/test/oauth2-service.test.ts
+++ b/test/oauth2-service.test.ts
@@ -756,6 +756,15 @@ describe('OAuth 2 service', () => {
     expect(res.headers.location).toBe(postLogoutRedirectUri);
   });
 
+  it('should show a page with the text "Logout successful" if no post_logout_redirect_uri was passed to the end_session_endpoint', async () => {
+    const res = await request(service.requestHandler)
+      .get('/endsession')
+      .redirects(0)
+      .expect(200);
+
+    expect(res.text).toBe("Logout successful");
+  });
+
   it('should be able to manipulate url and query params when redirecting within post_logout_redirect_uri', async () => {
     const postLogoutRedirectUri = 'http://example.com/signin?param=test';
 


### PR DESCRIPTION
Closes #233

## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Instead of throwing an error if the post logout redirect url isn't present no redirect will happen but instead a simple page with the text "Logout successful" will be returned. It can be used to verify the logout e.g. during integration tests.
