### PR TITLE
Add PKCE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,14 @@ request.get(
 );
 ```
 
+### Supported grant types
+
+- No authentication
+- Client Credentials grant
+- Resource Owner Password Credentials grant
+- Authorization Code grant, with Proof Key for Code Exchange (PKCE) support
+- Refresh token grant
+
 ### Supported JWK formats
 
 | Algorithm         | kty | alg                         |
@@ -220,13 +228,7 @@ Returns the JSON Web Key Set (JWKS) of all the keys configured in the server.
 
 ### POST `/token`
 
-Issues access tokens. Currently, this endpoint is limited to:
-
-- No authentication
-- Client Credentials grant
-- Resource Owner Password Credentials grant
-- Authorization code grant
-- Refresh token grant
+Issues access tokens.
 
 ### GET `/authorize`
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "lint": "eslint --cache --cache-location .cache/ --ext=.ts src test --max-warnings 0",
     "prepack": "yarn build --tsBuildInfoFile null --incremental false",
     "pretest": "yarn lint",
-    "test": "yarn vitest --run  --coverage"
+    "test": "yarn vitest --run  --coverage",
+    "test:watch": "yarn vitest --watch"
   },
   "dependencies": {
     "basic-auth": "^2.0.1",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,5 +1,6 @@
 import { ServerOptions } from 'https';
 import { JWKWithKid } from './types-internals';
+import { supportedPkceAlgorithms } from './helpers';
 
 export interface TokenRequest {
   scope?: string;
@@ -8,6 +9,7 @@ export interface TokenRequest {
   client_id?: unknown;
   code?: string;
   aud?: string[] | string;
+  code_verifier?: string;
 }
 
 export interface Options {
@@ -105,4 +107,11 @@ export type OAuth2EndpointsInput = Partial<OAuth2Endpoints>;
 
 export interface OAuth2Options {
   endpoints?: OAuth2EndpointsInput;
+}
+
+export type PKCEAlgorithm = (typeof supportedPkceAlgorithms)[number];
+
+export interface CodeChallenge {
+  challenge: string;
+  method: PKCEAlgorithm;
 }

--- a/test/helpers.test.ts
+++ b/test/helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import type { AddressInfo } from 'net';
 
 import {
@@ -7,8 +7,13 @@ import {
   assertIsString,
   assertIsStringOrUndefined,
   assertIsValidTokenRequest,
+  createPKCECodeChallenge,
+  createPKCEVerifier,
+  isValidPkceCodeVerifier,
+  pkceVerifierMatchesChallenge,
   shift,
 } from '../src/lib/helpers';
+import { CodeChallenge, PKCEAlgorithm } from '../src';
 
 describe('helpers', () => {
   describe('assertIsString', () => {
@@ -125,6 +130,60 @@ describe('helpers', () => {
 
     it('does not throw on valid input', () => {
       expect(() => shift(["a"])).not.toThrow();
+    });
+  });
+
+  describe('pkce', () => {
+    describe('code_verifier', () => {
+      it('should accept a valid PKCE code_verifier', () => {
+        const verifier128 =
+          'PXa7p8YHHUAJGrcG2eW0x7FY_EBtRTlaUHnyz1jKWnNp0G-2HZt9KjA0UOp87DmuIqoV4Y_owVsM-QICvrSa5dWxOndVEhSsFMMgy68AYkw4PGHkGaN_aIRIHJ8mQ4EZ';
+        const verifier42 = 'xyo94uhy3zKvgB0NJwLms86SwcjtWviEOpkBnGgaLlo';
+        expect(isValidPkceCodeVerifier(verifier128)).toBe(true);
+        expect(isValidPkceCodeVerifier(verifier42)).toBe(true);
+
+        const verifierWith129chars = `${verifier128}a`;
+        expect(isValidPkceCodeVerifier(verifierWith129chars)).toBe(false);
+        expect(
+          isValidPkceCodeVerifier(verifier42.slice(0, verifier42.length - 1))
+        ).toBe(false);
+      });
+
+      it('should create a valid code_verifier', () => {
+        expect(isValidPkceCodeVerifier(createPKCEVerifier())).toBe(true);
+      });
+
+      it('should create a valid code_challenge', async () => {
+        const verifier = 'xyo94uhy3zKvgB0NJwLms86SwcjtWviEOpkBnGgaLlo';
+        const expectedChallenge = 'b7elB7ZyxIXgFyvBznKvxl7wOB-H17Pz0a3B62NIMFI';
+        const generatedCodeChallenge = await createPKCECodeChallenge(
+          verifier,
+          'S256'
+        );
+        expect(generatedCodeChallenge).toBe(expectedChallenge);
+        const expectedCodeLength = 43; // BASE64-urlencoded sha256 hashes should always be 43 characters in length.
+        expect(
+          await createPKCECodeChallenge(createPKCEVerifier(), 'S256')
+        ).toHaveLength(expectedCodeLength);
+      });
+
+      it('should match code_verifier and code_challenge', async () => {
+        const verifier = createPKCEVerifier();
+        const codeChallengeMethod = 'S256';
+        const challenge: CodeChallenge = {
+          challenge: await createPKCECodeChallenge(
+            verifier,
+            codeChallengeMethod
+          ),
+          method: codeChallengeMethod,
+        };
+        expect(await pkceVerifierMatchesChallenge(verifier, challenge)).toBe(true);
+      });
+
+      it('should throw on an unsupported method', async () => {
+        const verifier = createPKCEVerifier();
+        await expect(createPKCECodeChallenge(verifier, 'BAD-METHOD' as PKCEAlgorithm)).rejects.toThrowError('Unsupported PKCE method ("BAD-METHOD")');
+      });
     });
   });
 });


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [x] If this is a significant change, an issue has already been created where the problem / solution was discussed: #218

## PR Description

This PR implements #218 which adds support for PKCE, both plain and SHA256-hashed code_verifier. It is based on the [RFC](https://datatracker.ietf.org/doc/html/rfc7636) and should be more-or-less compliant with it.

However, it is implemented as an opt-in approach _(which means that it does not support OAuth2.1 since there PKCE is always mandatory. But that was not required for the task either I assume)_. 
This means that if the requests does not have anything related to PKCE in them, then everything works as before.

## Attribution

This PR is merely a squash and minimal code cleanup from PR #245 (thanks @tanettrimas!)