### PR TITLE
Apply npm pkg fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     }
   },
   "bin": {
-    "oauth2-mock-server": "./dist/oauth2-mock-server.mjs"
+    "oauth2-mock-server": "dist/oauth2-mock-server.mjs"
   },
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
## PR Checklist

- [ ] I have run `npm test` locally and all tests are passing.
- [ ] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Seems @poveden hit this message during last publish attempt

```
❯ npm publish
npm warn package-json oauth2-mock-server@8.2.3 No bin file found at dist/oauth2-mock-server.mjs
npm warn package-json oauth2-mock-server@8.2.3 No bin file found at dist/oauth2-mock-server.mjs
 
> oauth2-mock-server@8.2.3 prepack
> npm run build
 
 
> oauth2-mock-server@8.2.3 build
> npx tsdown
 
ℹ tsdown v0.21.10 powered by rolldown v1.0.0-rc.17
ℹ config file: [REDACTED]\oauth2-mock-server\tsdown.config.ts
ℹ entry: src/index.ts, src/oauth2-mock-server.ts
ℹ target: node20.19.0
ℹ tsconfig: tsconfig.json
ℹ Build start
ℹ Cleaning 7 files
ℹ Granting execute permission to dist\oauth2-mock-server.mjs
ℹ dist\oauth2-mock-server.mjs         6.88 kB │ gzip: 2.51 kB
ℹ dist\index.mjs                      0.23 kB │ gzip: 0.16 kB
ℹ dist\oauth2-server-Bqq5vOCR.mjs    32.89 kB │ gzip: 8.59 kB
ℹ dist\index.d.mts                    0.94 kB │ gzip: 0.38 kB
ℹ dist\oauth2-mock-server.d.mts       0.20 kB │ gzip: 0.17 kB
ℹ dist\oauth2-server-ByGa3_0f.d.mts  10.46 kB │ gzip: 2.93 kB
ℹ 6 files, total: 51.61 kB
✔ Build complete in 556ms
npm warn publish npm auto-corrected some errors in your package.json when publishing.  Please run "npm pkg fix" to address these errors.
npm warn publish errors corrected:
npm warn publish "bin[oauth2-mock-server]" script name dist/oauth2-mock-server.mjs was invalid and removed
npm notice
npm notice package: oauth2-mock-server@8.2.3
npm notice Tarball Contents
npm notice 12.0kB CHANGELOG.md
npm notice 1.1kB LICENSE.md
npm notice 2.9kB MIGRATION.md
npm notice 8.3kB README.md
npm notice 942B dist/index.d.mts
npm notice 234B dist/index.mjs
npm notice 203B dist/oauth2-mock-server.d.mts
npm notice 6.9kB dist/oauth2-mock-server.mjs
npm notice 32.9kB dist/oauth2-server-Bqq5vOCR.mjs
npm notice 10.5kB dist/oauth2-server-ByGa3_0f.d.mts
npm notice 2.4kB package.json
npm notice Tarball Details
npm notice name: oauth2-mock-server
npm notice version: 8.2.3
npm notice filename: oauth2-mock-server-8.2.3.tgz
npm notice package size: 20.9 kB
npm notice unpacked size: 78.2 kB
npm notice shasum: d1809f347d705cba1d2a881a28639c224bfbd6d1
npm notice integrity: sha512-yrHb4ErU/Nk7G[...]1ThXzj37cRggw==
npm notice total files: 11
```