### PR TITLE
Teach `/token` endpoint to support `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,22 +10,23 @@ This file contains instructions for AI coding agents working in this repository.
 
 ### Module map
 
-| File                             | Role                                                                                                                                            |
-| -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `src/index.ts`                   | Public barrel — all library exports originate here                                                                                              |
-| `src/oauth2-mock-server.ts`      | Binary shim — calls `cli()` from `src/cli.ts` with `process.argv.slice(2)`; contains no logic                                                   |
-| `src/cli.ts`                     | CLI logic — `cli(args)` parses argv and starts the server; also exports `readJsonFromFile()` and `shift()`; not part of the public API          |
-| `src/lib/http-server.ts`         | `HttpServer` — restartable wrapper around `node:http`/`node:https`                                                                              |
-| `src/lib/jwk-store.ts`           | `JWKStore` — manages JWK key pairs; uses `jose` for key generation/export                                                                       |
-| `src/lib/jwk-store.keys.ts`      | JWK algorithm registry: `supportedAlgs` list and `privateToPublicKeyTransformer`; used by `JWKStore` and test helpers — not exported publicly   |
-| `src/lib/oauth2-issuer.ts`       | `OAuth2Issuer` — holds the issuer URL + key store; signs JWTs with `jose` (`SignJWT`)                                                           |
-| `src/lib/oauth2-service.ts`      | `OAuth2Service` — HTTP request handler; owns all OAuth2/OIDC endpoint logic; composes `OAuth2Issuer`                                            |
-| `src/lib/oauth2-service.http.ts` | HTTP plumbing for `OAuth2Service`: body/query-param parsing, route matching — not exported publicly                                             |
-| `src/lib/oauth2-service.pkce.ts` | PKCE utilities: `isValidPkceCodeVerifier`, `createPKCEVerifier`, `createPKCECodeChallenge` — not exported publicly                              |
-| `src/lib/oauth2-server.ts`       | `OAuth2Server` — convenience façade; combines `HttpServer` + `OAuth2Service` + `OAuth2Issuer`                                                   |
-| `src/lib/assertions.ts`          | Internal assertion helpers: `assertIsString`, `assertIsStringOrUndefined`, `assertIsAddressInfo`, `assertIsPlainObject` — not exported publicly |
-| `src/lib/types.ts`               | Public types and interfaces (exported via barrel)                                                                                               |
-| `src/lib/types-internals.ts`     | Internal types (`JWKWithKid`, `AugmentedRequest`, `RouteHandler`, `InternalEvents`, `supportedPkceAlgorithms`) — **not** re-exported            |
+| File                                      | Role                                                                                                                                                |
+| ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/index.ts`                            | Public barrel — all library exports originate here                                                                                                  |
+| `src/oauth2-mock-server.ts`               | Binary shim — calls `cli()` from `src/cli.ts` with `process.argv.slice(2)`; contains no logic                                                       |
+| `src/cli.ts`                              | CLI logic — `cli(args)` parses argv and starts the server; also exports `readJsonFromFile()` and `shift()`; not part of the public API              |
+| `src/lib/http-server.ts`                  | `HttpServer` — restartable wrapper around `node:http`/`node:https`                                                                                  |
+| `src/lib/jwk-store.ts`                    | `JWKStore` — manages JWK key pairs; uses `jose` for key generation/export                                                                           |
+| `src/lib/jwk-store.keys.ts`               | JWK algorithm registry: `supportedAlgs` list and `privateToPublicKeyTransformer`; used by `JWKStore` and test helpers — not exported publicly       |
+| `src/lib/oauth2-issuer.ts`                | `OAuth2Issuer` — holds the issuer URL + key store; signs JWTs with `jose` (`SignJWT`)                                                               |
+| `src/lib/oauth2-service.ts`               | `OAuth2Service` — HTTP request handler; owns all OAuth2/OIDC endpoint logic; composes `OAuth2Issuer`                                                |
+| `src/lib/oauth2-service.http.ts`          | HTTP plumbing for `OAuth2Service`: body/query-param parsing, route matching — not exported publicly                                                 |
+| `src/lib/oauth2-service.pkce.ts`          | PKCE utilities: `isValidPkceCodeVerifier`, `createPKCEVerifier`, `createPKCECodeChallenge` — not exported publicly                                  |
+| `src/lib/oauth2-service.jwt-assertion.ts` | JWT Bearer assertion parsing: `parseJwtBearerAssertionPayload` — decodes the payload segment without verifying the signature; not exported publicly |
+| `src/lib/oauth2-server.ts`                | `OAuth2Server` — convenience façade; combines `HttpServer` + `OAuth2Service` + `OAuth2Issuer`                                                       |
+| `src/lib/assertions.ts`                   | Internal assertion helpers: `assertIsString`, `assertIsStringOrUndefined`, `assertIsAddressInfo`, `assertIsPlainObject` — not exported publicly     |
+| `src/lib/types.ts`                        | Public types and interfaces (exported via barrel)                                                                                                   |
+| `src/lib/types-internals.ts`              | Internal types (`JWKWithKid`, `AugmentedRequest`, `RouteHandler`, `InternalEvents`, `supportedPkceAlgorithms`) — **not** re-exported                |
 
 **Key dependency**: `jose` (async, Promise-based API) is used for all JWK generation, JWT signing, and key import/export.
 
@@ -110,7 +111,8 @@ Tests are the **behavioural contract** of this library and are more critical tha
 ### Test integrity — read carefully
 
 - **Every code change must be accompanied by unit tests** that cover the new or modified behaviour. A PR without tests for its changes will not be accepted.
-- **All code branches must be covered.** When a branch genuinely cannot be reached in tests (e.g. a defensive assertion against an impossible runtime state), you **must** explicitly tell the user which branch is uncovered, why it cannot be tested, and what the underlying reason is. Do not silently leave branches uncovered.
+- **New source modules require a dedicated test file.** Every new `src/lib/foo.ts` must have a corresponding `test/foo.test.ts` that tests the module directly, not only indirectly through another module's tests. Tests in an unrelated test file are not a substitute.
+- **All code branches must be covered.** When a branch genuinely cannot be reached in tests (e.g. a defensive assertion against an impossible runtime state), you **must** explicitly tell the user which branch is uncovered, why it cannot be tested, and what the underlying reason is. Do not silently leave branches uncovered. Prefer refactoring to remove unreachable branches over leaving them as dead code.
 - **Modifying existing passing tests is strictly forbidden** without the explicit agreement of the user. If you believe a test must be changed, stop, explain clearly which test you want to modify and exactly why, and wait for approval before touching it.
 
 ### Conventions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
+## Unreleased
+
+### Added
+
+- Teach `/token` endpoint to support `urn:ietf:params:oauth:grant-type:jwt-bearer` grant type and JWT bearer assertions (cf. https://datatracker.ietf.org/doc/html/rfc7523)
+
 ## [9.0.0](https://github.com/axa-group/oauth2-mock-server/compare/v8.2.3...v9.0.0) — 2026-06-05
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ oAuth2Service.addRoute('POST', '/api/v2/clients', (req, res) => {
 - Resource Owner Password Credentials grant
 - Authorization Code grant, with Proof Key for Code Exchange (PKCE) support
 - Refresh token grant
+- JWT Bearer token grant (`urn:ietf:params:oauth:grant-type:jwt-bearer`)
 
 ### Supported JWK formats
 

--- a/src/lib/assertions.ts
+++ b/src/lib/assertions.ts
@@ -90,6 +90,10 @@ export function assertIsValidTokenRequest(
   if ('aud' in body) {
     validateAudField(body['aud']);
   }
+
+  if ('assertion' in body) {
+    assertIsString(body['assertion'], "Invalid 'assertion' type");
+  }
 }
 
 function generateRandomKid(): string {

--- a/src/lib/oauth2-service.jwt-assertion.ts
+++ b/src/lib/oauth2-service.jwt-assertion.ts
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) AXA Assistance France
+ *
+ * Licensed under the AXA Assistance France License (the "License"); you
+ * may not use this file except in compliance with the License.
+ * A copy of the License can be found in the LICENSE.md file distributed
+ * together with this file.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** @module lib/oauth2-service.jwt-assertion */
+
+import { Buffer } from 'node:buffer';
+import { AssertionError } from 'node:assert';
+
+import { assertIsPlainObject, assertIsString } from './assertions';
+
+export const jwtBearerGrantType = 'urn:ietf:params:oauth:grant-type:jwt-bearer';
+
+export interface JwtBearerAssertionPayload {
+  sub: string;
+  [key: string]: unknown;
+}
+
+/**
+ * Parses the payload part of a JWT Bearer assertion.
+ * The JWT signature is intentionally ignored because this mock server does not
+ * cryptographically validate incoming assertions.
+ * @param assertion The incoming JWT assertion.
+ * @returns The decoded payload object.
+ */
+export function parseJwtBearerAssertionPayload(
+  assertion: string,
+): JwtBearerAssertionPayload {
+  const encodedPayload = assertion.split('.').at(1);
+
+  if (encodedPayload === undefined) {
+    throw new AssertionError({
+      message: "Invalid 'assertion' format: expected at least header.payload",
+    });
+  }
+
+  const decodedPayload = Buffer.from(encodedPayload, 'base64url').toString(
+    'utf8',
+  );
+
+  let payload: unknown;
+  try {
+    payload = JSON.parse(decodedPayload) as unknown;
+  } catch {
+    throw new AssertionError({
+      message: "Invalid 'assertion' payload: malformed JSON",
+    });
+  }
+
+  assertIsPlainObject(
+    payload,
+    "Invalid 'assertion' payload: expected an object",
+  );
+
+  assertIsString(
+    payload['sub'],
+    "Invalid 'assertion' payload: 'sub' claim is expected to be a string",
+  );
+
+  return payload as JwtBearerAssertionPayload;
+}

--- a/src/lib/oauth2-service.ts
+++ b/src/lib/oauth2-service.ts
@@ -65,6 +65,16 @@ import {
   isValidPkceCodeVerifier,
   pkceVerifierMatchesChallenge,
 } from './oauth2-service.pkce';
+import {
+  jwtBearerGrantType,
+  parseJwtBearerAssertionPayload,
+} from './oauth2-service.jwt-assertion';
+
+const grantsIssuingIdToken = new Set([
+  'authorization_code',
+  'password',
+  'refresh_token',
+]);
 
 const DEFAULT_ENDPOINTS: OAuth2Endpoints = Object.freeze({
   wellKnownDocument: '/.well-known/openid-configuration',
@@ -252,6 +262,7 @@ export class OAuth2Service extends EventEmitter {
         'client_credentials',
         'authorization_code',
         'password',
+        jwtBearerGrantType,
       ],
       token_endpoint_auth_signing_alg_values_supported: ['RS256'],
       response_modes_supported: ['query'],
@@ -338,6 +349,22 @@ export class OAuth2Service extends EventEmitter {
           Object.assign(payload, { sub: 'johndoe', amr: ['pwd'], scope });
         };
         break;
+      case jwtBearerGrantType: {
+        assertIsString(reqBody.assertion, "Invalid 'assertion' type");
+
+        const assertionPayload = parseJwtBearerAssertionPayload(
+          reqBody.assertion,
+        );
+
+        xfn = (_header, payload) => {
+          Object.assign(payload, {
+            sub: assertionPayload.sub,
+            client_id: assertionPayload.sub,
+            scope,
+          });
+        };
+        break;
+      }
       default:
         throw new AssertionError({ message: 'Invalid grant type' });
     }
@@ -354,7 +381,7 @@ export class OAuth2Service extends EventEmitter {
       scope,
     };
 
-    if (reqBody.grant_type !== 'client_credentials') {
+    if (grantsIssuingIdToken.has(reqBody.grant_type)) {
       const credentials = basicAuth(req);
       const clientId = credentials ? credentials.name : reqBody.client_id;
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,7 @@ export interface TokenRequest {
   code?: string;
   aud?: string[] | string;
   code_verifier?: string;
+  assertion?: string;
 }
 
 export interface TokenRequestIncomingMessage extends IncomingMessage {

--- a/test/assertions.test.ts
+++ b/test/assertions.test.ts
@@ -92,6 +92,7 @@ describe('assertIsValidTokenRequest', () => {
     { grant_type: "g", scope: 1, code: "c" },
     { grant_type: "g", scope: "1", code: "c", aud: 1 },
     { grant_type: "g", scope: "1", code: "c", aud: [1] },
+    { grant_type: "g", assertion: 1 },
   ])('throws on wrong values (%s)', (input) => {
     expect(() => { assertIsValidTokenRequest(input); }).toThrow();
   });
@@ -103,6 +104,7 @@ describe('assertIsValidTokenRequest', () => {
     { grant_type: "g", scope: "s", code: "c" },
     { grant_type: "g", scope: "s", code: "c", aud: "a" },
     { grant_type: "g", scope: "s", code: "c", aud: ["a", "b"] },
+    { grant_type: "g", assertion: "header.payload.signature" },
   ])('does not throw on valid input (%s)', (input) => {
     expect(() => { assertIsValidTokenRequest(input); }).not.toThrow();
   });

--- a/test/lib/test_helpers.ts
+++ b/test/lib/test_helpers.ts
@@ -54,3 +54,11 @@ export function assert400ProblemDetails(res: request.Response, detail: string) {
 
   expect(res.headers['content-type']).toMatch(/application\/problem\+json/);
 }
+
+export function createJwtAssertion(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+
+  // Signature ommitted on purpose since this mock server explicitly ignores it
+  return `${header}.${body}`;
+}

--- a/test/oauth2-service.jwt-assertion.test.ts
+++ b/test/oauth2-service.jwt-assertion.test.ts
@@ -1,0 +1,93 @@
+import { Buffer } from 'node:buffer';
+
+import { describe, expect, it } from 'vitest';
+
+import { parseJwtBearerAssertionPayload } from '../src/lib/oauth2-service.jwt-assertion';
+
+import { createJwtAssertion } from './lib/test_helpers';
+
+describe('parseJwtBearerAssertionPayload', () => {
+  describe('format validation', () => {
+    it('throws when assertion contains no dot (single segment)', () => {
+      expect(() => parseJwtBearerAssertionPayload('notajwt')).toThrow(
+        "Invalid 'assertion' format: expected at least header.payload",
+      );
+    });
+
+    it('throws when assertion is an empty string', () => {
+      expect(() => parseJwtBearerAssertionPayload('')).toThrow(
+        "Invalid 'assertion' format: expected at least header.payload",
+      );
+    });
+  });
+
+  describe('payload JSON validation', () => {
+    it('throws when the payload segment decodes to invalid JSON', () => {
+      // 'abc' in base64url decodes to bytes whose utf-8 text is not valid JSON
+      const assertion = `eyJhbGciOiJub25lIn0.abc.ignored`;
+
+      expect(() => parseJwtBearerAssertionPayload(assertion)).toThrow(
+        "Invalid 'assertion' payload: malformed JSON",
+      );
+    });
+
+    it('throws when the payload segment is a valid JSON string but not an object', () => {
+      const assertion = `eyJhbGciOiJub25lIn0.${Buffer.from(JSON.stringify([1, 2, 3])).toString('base64url')}.ignored`;
+
+      expect(() => parseJwtBearerAssertionPayload(assertion)).toThrow(
+        "Invalid 'assertion' payload: expected an object",
+      );
+    });
+
+    it('throws when the payload segment is a valid JSON number', () => {
+      const assertion = `eyJhbGciOiJub25lIn0.${Buffer.from('42').toString('base64url')}.ignored`;
+
+      expect(() => parseJwtBearerAssertionPayload(assertion)).toThrow(
+        "Invalid 'assertion' payload: expected an object",
+      );
+    });
+
+    it('throws when the payload segment is missing a sub claim', () => {
+      const assertion = createJwtAssertion({ iss: 'client-app' });
+
+      expect(() => parseJwtBearerAssertionPayload(assertion)).toThrow(
+        "Invalid 'assertion' payload: 'sub' claim is expected to be a string",
+      );
+    });
+
+    it('throws when the payload segment is exposing a non string sub claim', () => {
+      const assertion = createJwtAssertion({ iss: 'client-app', sub: 123 });
+
+      expect(() => parseJwtBearerAssertionPayload(assertion)).toThrow(
+        "Invalid 'assertion' payload: 'sub' claim is expected to be a string",
+      );
+    });
+  });
+
+  describe('successful decoding', () => {
+    const payload = {
+      sub: 'user@example.com',
+      iss: 'client-app',
+      aud: 'https://resource.example.com',
+      iat: 1700000000,
+      exp: 1700003600,
+      custom_claim: 'custom-value',
+    };
+
+    it('returns the decoded payload from a 2-part assertion (no signature)', () => {
+      const assertion = createJwtAssertion(payload);
+
+      const result = parseJwtBearerAssertionPayload(assertion);
+
+      expect(result).toEqual(payload);
+    });
+
+    it('returns the decoded payload from a 3-part assertion (with signature segment)', () => {
+      const assertion = createJwtAssertion(payload) + '.ignored-signature';
+
+      const result = parseJwtBearerAssertionPayload(assertion);
+
+      expect(result).toEqual(payload);
+    });
+  });
+});

--- a/test/oauth2-service.test.ts
+++ b/test/oauth2-service.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../src/lib/oauth2-service.pkce';
 
 import * as testKeys from './keys';
-import { assert400ProblemDetails, verifyTokenWithKey } from './lib/test_helpers';
+import { assert400ProblemDetails, createJwtAssertion, verifyTokenWithKey } from './lib/test_helpers';
 
 describe('OAuth2Service endpoint validation', () => {
   it('should accept undefined endpoints', () => {
@@ -129,7 +129,12 @@ describe.each([
         token_endpoint_auth_methods_supported: ['none'],
         jwks_uri: `${endpointsPrefix}/jwks`,
         response_types_supported: ['code'],
-        grant_types_supported: ['client_credentials', 'authorization_code', 'password'],
+        grant_types_supported: [
+          'client_credentials',
+          'authorization_code',
+          'password',
+          'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        ],
         token_endpoint_auth_signing_alg_values_supported: ['RS256'],
         response_modes_supported: ['query'],
         id_token_signing_alg_values_supported: ['RS256'],
@@ -431,6 +436,116 @@ describe.each([
         sub: 'johndoe',
         amr: ['pwd'],
       });
+    });
+
+    it('should expose a token endpoint that handles jwt-bearer grants', async () => {
+      const assertion = createJwtAssertion({
+        sub: 'service-account@example.com',
+      });
+
+      const res = await tokenRequest(service.requestHandler)
+        .send({
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion,
+          scope: 'urn:first-scope urn:second-scope',
+        })
+        .expect(200);
+
+      expect(res.body).toMatchObject({
+        access_token: expect.any(String),
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'urn:first-scope urn:second-scope',
+      });
+      expect(res.body).not.toHaveProperty('id_token');
+      expect(res.body).not.toHaveProperty('refresh_token');
+
+      const resBody = res.body as { access_token: string; scope: string };
+      const decoded = await verifyTokenWithKey(
+        service.issuer,
+        resBody.access_token,
+        'test-rs256-key',
+      );
+
+      expect(decoded.payload).toMatchObject({
+        iss: service.issuer.url,
+        sub: 'service-account@example.com',
+        client_id: 'service-account@example.com',
+        scope: resBody.scope,
+      });
+    });
+
+    it('should expose a token endpoint that handles jwt-bearer grants with no scope', async () => {
+      const assertion = createJwtAssertion({ sub: 'service-account@example.com' });
+
+      const res = await tokenRequest(service.requestHandler)
+        .send({
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion,
+        })
+        .expect(200);
+
+      expect(res.body).not.toHaveProperty('scope');
+      expect(res.body).not.toHaveProperty('id_token');
+      expect(res.body).not.toHaveProperty('refresh_token');
+
+      const resBody = res.body as { access_token: string };
+      const decoded = await verifyTokenWithKey(service.issuer, resBody.access_token, 'test-rs256-key');
+
+      expect(decoded.payload).toMatchObject({
+        sub: 'service-account@example.com',
+        client_id: 'service-account@example.com',
+      });
+      expect(decoded.payload).not.toHaveProperty('scope');
+    });
+
+    it('should reject a jwt-bearer grant without assertion', async () => {
+      const res = await tokenRequest(service.requestHandler)
+        .send({
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+        });
+
+      assert400ProblemDetails(res, "Invalid 'assertion' type");
+    });
+
+    it('should reject a jwt-bearer grant with an invalid assertion format', async () => {
+      const res = await tokenRequest(service.requestHandler)
+        .send({
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion: 'not-a-jwt',
+        });
+
+      assert400ProblemDetails(
+        res,
+        "Invalid 'assertion' format: expected at least header.payload",
+      );
+    });
+
+    it('should reject a jwt-bearer grant with a malformed assertion payload', async () => {
+      const assertion = ['eyJhbGciOiJub25lIn0', '!!!!', 'ignored-signature'].join('.');
+
+      const res = await tokenRequest(service.requestHandler)
+        .send({
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion,
+        });
+
+      assert400ProblemDetails(res, "Invalid 'assertion' payload: malformed JSON");
+    });
+
+    it('should reject a jwt-bearer grant with no sub claim in assertion payload', async () => {
+      const assertion = createJwtAssertion({ aud: 'https://example.com/token' });
+
+      const res = await tokenRequest(service.requestHandler)
+        .send({
+          grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+          assertion,
+        });
+
+      assert400ProblemDetails(
+        res,
+        "Invalid 'assertion' payload: 'sub' claim is expected to be a string",
+      );
     });
 
     it('should expose a token endpoint that remembers nonce', async () => {


### PR DESCRIPTION
## PR Checklist

- [x] I have run `npm test` locally and all tests are passing.
- [x] I have added/updated tests for any new behavior.
- [ ] If this is a significant change, an issue has already been created where the problem / solution was discussed: [N/A, or add link to issue here]

## PR Description

Among other things, should make integration testing of upcoming MCP servers easier (cf. https://modelcontextprotocol.io/extensions/auth/oauth-client-credentials#jwt-bearer-assertions-recommended)